### PR TITLE
Only include .svg images when reading directory

### DIFF
--- a/lib/svg_processor.rb
+++ b/lib/svg_processor.rb
@@ -8,7 +8,7 @@ class SVGProcessor
   end
 
   def rebuild
-    @svgs = Dir["#{@path}/*"].map { |file| get_svg(file) }
+    @svgs = Dir["#{@path}/*.svg"].map { |file| get_svg(file) }
     puts "rebuilding: #{@svgs.length} svgs found"
     @symbols = @svgs.map { |svg| convert_to_symbol(svg) }
 


### PR DESCRIPTION
Previously, all the files in the specified directory would be read, and
if the processor encounters a non-svg file it will throw an exception.
Long-term solution is probably to do some more heuristics and actually
catch thrown exceptions without crashing everything but this is a nice
band-aid for now.
