### PR TITLE
Fix difference between source dir and async loading dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 A Middleman extension for creating svg sprite sheets. It's usable in modern (IE9+) browsers, uses `<symbol>` to include the svg:s, and can optionally inline the SVG images for speed. If you need legacy browser support it combines well with [svg4everybody](https://github.com/jonathantneal/svg4everybody).
 
+## Important info about older and newer middleman versions!
+
+A bunch of things have happened in Middleman core since this plugin was created. There were some changes between minor versions in Middleman 3.x in regard to how files are resolved. This created some unfortunate incompatibilities in middleman-scavenger and to simplify things, the master branch of middleman-scavenger is only compatible with 3.4.x. Middleman 4 has thrown out the Sprockets asset pipeline completely, which is... interesting for us. So, in short:
+
+- If you're using Middleman 3.4.x, just include everything as usual
+- If you're on Middleman 3.3.x (or maybe earlier?) you should lock your version of `middleman-scavenger` to 1.0.2
+- If you've upgraded to Middleman 4, hold on while we figure things out and use [This branch](https://github.com/varvet/middleman-scavenger/tree/feature/middleman-4-support) in the meantime, as documented [here](https://github.com/varvet/middleman-scavenger/pull/11).
 
 ## Installation and quick start
 
@@ -26,7 +33,7 @@ If you don't like the default settings, you can change them at activation time. 
   activate :middleman_scavenger do |config|
     config.path = "./source/my-svg-directory/"
     config.prefix = "icon-"
-    config.sprite_path = "another-directory/my-sprite.svg"
+    config.sprite_path = "source/javascripts/my-sprite.svg"
   end
 ```
 
@@ -54,14 +61,14 @@ If you want to reference the sprite directly, you can use `scavenger_sprite_path
 
 Middleman-scavenger uses an SVG processor based on [Nokogiri](http://www.nokogiri.org) to load and parse the SVG images in the folder into a sprite sheet, each image in its own `<symbol>` with its own viewBox. The sprite sheet is cached in memory and written to disk, so it can be asynchronously loaded or quickly inlined into the document. Whenever an SVG is added, removed, or changed in development mode Middleman-scavenger will make a new in-memory and on-disk version. The rebuild process fires at build time as well.
 
-The bundled javascript will asynchronously load the SVG sprite sheet as text and insert it at the top of the body. This makes it possible to control the SVG sprites via CSS. An externally referenced SVG will create a shadow DOM boundary that is impossible to cross, but inserting the sprite sheet into the document removes that obstacle and makes for easy transitions and hover states.
+The bundled javascript will asynchronously load the SVG sprite sheet as text and insert it at the top of the body. This makes it possible to control the SVG sprites via CSS. An externally referenced SVG will create a shadow DOM boundary that is impossible to cross, but inserting the sprite sheet into the document removes that obstacle and makes it possible to control transitions and hover states.
 
 
 ## Gotchas
 
 ### Sizing
 
-SVG sizing is always a little difficult, and even more so with sprite sheets. Middleman-scavenger uses [Nokogiri](http://www.nokogiri.org) to parse the SVG images and put them in `<symbol>` elements, so each image can have its own viewBox. That way, they will scale as expected when given width or height parameters. Including an SVG without sizing information will constrain it to the dimensions of the element it was included in, so it's advisable to add `width:` or `height:` or a styled CSS selector to the `svg` helper.
+SVG sizing is always a little difficult, and even more so with sprite sheets. Middleman-scavenger allows each image to have its own viewBox, which means they will scale as expected when given width or height parameters. Including an SVG without sizing information will constrain it to the dimensions of the element it was included in, so it's advisable to add `width:` or `height:` or a styled CSS selector to the `svg` helper.
 
 
 ### FONI

--- a/assets/javascripts/middleman-scavenger.js.erb
+++ b/assets/javascripts/middleman-scavenger.js.erb
@@ -7,7 +7,7 @@
   function requestSprite() {
     var oReq = new XMLHttpRequest();
     oReq.addEventListener('load', requestListener);
-    oReq.open('GET', '<%= image_path svg_sprite_path %>');
+    oReq.open('GET', '<%= scavenger_sprite_path %>');
     oReq.send();
   }
 

--- a/lib/middleman-scavenger.rb
+++ b/lib/middleman-scavenger.rb
@@ -5,14 +5,14 @@ require "middleman-core"
 class MiddlemanScavenger < ::Middleman::Extension
   option :path, "./source/images/svg", "Directory containing SVG files"
   option :prefix, "", "Optional prefix for icon names"
-  option :sprite_path, "sprite.svg", "Static file to write svg spritesheet to"
+  option :sprite_path, "./source/images/sprite.svg", "Static file to write svg spritesheet to"
 
   def initialize(app, options_hash={}, &block)
     super
 
     require "svg_processor"
 
-    processor_instance = SVGProcessor.new(options.path, options.prefix, "source/#{options.sprite_path}")
+    processor_instance = SVGProcessor.new(options.path, options.prefix, options.sprite_path)
     processor_instance.rebuild
     app.set :svg_processor, processor_instance
     app.set :svg_sprite_path, options.sprite_path
@@ -34,7 +34,7 @@ class MiddlemanScavenger < ::Middleman::Extension
 
   helpers do
     def scavenger_sprite_path
-      image_path svg_sprite_path
+      image_path File.basename(svg_sprite_path)
     end
 
     def inline_svg_sprite

--- a/lib/middleman-scavenger.rb
+++ b/lib/middleman-scavenger.rb
@@ -12,7 +12,7 @@ class MiddlemanScavenger < ::Middleman::Extension
 
     require "svg_processor"
 
-    processor_instance = SVGProcessor.new(options.path, options.prefix, options.sprite_path)
+    processor_instance = SVGProcessor.new(options.path, options.prefix, "source/#{options.sprite_path}")
     processor_instance.rebuild
     app.set :svg_processor, processor_instance
     app.set :svg_sprite_path, options.sprite_path

--- a/lib/svg_processor.rb
+++ b/lib/svg_processor.rb
@@ -10,7 +10,7 @@ class SVGProcessor
 
   def rebuild
     @svgs = Dir["#{@path}/*.svg"].map { |file| get_svg(file) }
-    logger.debug "rebuilding: #{@svgs.length} svgs found"
+    logger.info "rebuilding: #{@svgs.length} svgs found"
     @symbols = @svgs.map { |svg| convert_to_symbol(svg) }
 
     @symbol_string = @symbols.join("\n")

--- a/middleman-scavenger.gemspec
+++ b/middleman-scavenger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # The version of middleman-core your extension depends on
-  s.add_runtime_dependency("middleman-core", [">= 3.3.1", "< 4.0.0"])
+  s.add_runtime_dependency("middleman-core", [">= 3.4.0", "< 4.0.0"])
 
   # Additional dependencies
   s.add_runtime_dependency("nokogiri", "~> 1.6")


### PR DESCRIPTION
There's been some changes to middleman-core that are breaking the gem, as per #14, with how assets are resolved relative to the paths. We don't want earlier 3.x versions and 3.4 to have different code paths, especially since 4.0 is already released, so let's just lock middleman-scavenger 1.x to version 3.4 and up.
